### PR TITLE
Update react-transform-hmr and its config

### DIFF
--- a/examples/react-transform-boilerplate/.babelrc
+++ b/examples/react-transform-boilerplate/.babelrc
@@ -4,13 +4,15 @@
     "react-transform"
   ],
   "extra": {
-    "react-transform": [{
-      "target": "react-transform-webpack-hmr",
-      "imports": ["react"],
-      "locals": ["module"]
-    }, {
-      "target": "react-transform-catch-errors",
-      "imports": ["react", "redbox-react"]
-    }]
+    "react-transform": {
+      "transforms": [{
+         "transform": "react-transform-hmr",
+         "imports": ["react"],
+         "locals": ["module"]
+      }, {
+         "transform": "react-transform-catch-errors",
+         "imports": ["react", "redbox-react"]
+      }]
+    }
   }
 }

--- a/examples/react-transform-boilerplate/package.json
+++ b/examples/react-transform-boilerplate/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-react": "^2.3.0",
     "express": "^4.13.3",
     "react-transform-catch-errors": "^0.1.1",
-    "react-transform-webpack-hmr": "^0.1.2",
+    "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.0.1",
     "webpack": "^1.9.6",
     "webpack-dev-middleware": "^1.2.0",


### PR DESCRIPTION
I've got a warning while enjoying an example so I decided to update this dependency.
